### PR TITLE
feat: add responsive route compare panel for better discoverability

### DIFF
--- a/docs/ux-route-comparison-options.md
+++ b/docs/ux-route-comparison-options.md
@@ -1,0 +1,117 @@
+# Route Comparison UI/UX Options Analysis
+
+## Problem Statement
+
+Two key discoverability issues with the route comparison feature:
+
+1. **RoutesDiv visibility**: The route comparison buttons at the top of the page were not being noticed by users
+2. **Add destination discoverability**: The MapPinPlus button on gym cards wasn't intuitive enough for users to understand its purpose
+
+## Options Considered
+
+### Option A: Current Layout + Improvements
+
+Keep the RoutesDiv at the top of the page but make the buttons bigger and more prominent.
+
+**Pros:**
+- Minimal code changes
+- No layout restructuring needed
+- Quick to implement
+
+**Cons:**
+- Doesn't solve the core discoverability problem
+- Users still may not notice the top bar
+- No visual feedback when gyms are selected
+
+**Verdict:** Quick fix but doesn't address the fundamental UX issue.
+
+---
+
+### Option B: Separate Compare Page
+
+Create a dedicated `/compare` page where users can select gyms and compare routes.
+
+**Pros:**
+- Clean separation of concerns
+- Dedicated space for comparison functionality
+- Can show more detailed comparison information
+
+**Cons:**
+- Adds navigation friction (users must go to a separate page)
+- Context switching between browsing gyms and comparing
+- Users may not discover the feature exists
+- Loses the "quick glance" benefit of comparing while browsing
+
+**Verdict:** Too much friction for a feature that should feel lightweight.
+
+---
+
+### Option C: Mode Toggle (Explore/Compare)
+
+Add a toggle on the home page to switch between "Explore" and "Compare" modes.
+
+**Pros:**
+- Clear separation of intent
+- Can optimize each mode for its purpose
+- Explicit user choice
+
+**Cons:**
+- Adds cognitive load (users must understand modes exist)
+- Users might not realize they need to switch modes
+- Could feel clunky for quick comparisons
+- Not a common pattern users would expect
+
+**Verdict:** Overcomplicates a simple interaction.
+
+---
+
+### Option D: Sticky Bottom/Side Panel (Selected)
+
+Implement a responsive panel that's always visible:
+- Mobile: Sticky bottom sheet (Google Maps mobile style)
+- Desktop: Sticky right side panel (Google Maps desktop style)
+
+**Pros:**
+- Familiar pattern (Google Maps, Uber, etc.)
+- Always visible, teaching users the feature exists
+- Non-intrusive when collapsed
+- Clear visual feedback when gyms are added
+- Auto-expand on first selection creates "aha" moment
+- Works well on both mobile and desktop
+- No navigation required
+
+**Cons:**
+- Takes up screen real estate
+- More complex implementation
+- Need to handle responsive breakpoints
+
+**Verdict:** Best balance of discoverability, usability, and familiarity.
+
+---
+
+## Implementation Decision
+
+**Selected: Option D - Sticky Bottom/Side Panel**
+
+### Rationale
+
+1. **Familiar Pattern**: Users recognize this pattern from Google Maps, making it immediately understandable
+2. **Always Accessible**: The panel is always visible, even when empty, which teaches users about the feature
+3. **Progressive Disclosure**: Collapsed state is minimal; expanded state shows full functionality
+4. **Contextual**: Users can compare routes while still browsing gyms
+5. **Mobile-First**: The bottom sheet pattern is native to mobile experiences
+
+### Key Behaviors
+
+1. Panel is **always visible** (even when empty) to teach users the feature exists
+2. **Auto-expand on first gym add** creates an "aha" moment and confirms the action worked
+3. After first use, panel stays in user's preferred collapsed/expanded state
+4. Travel mode buttons are **disabled when no gyms selected** to prevent confusion
+5. Gym icons are **removable** directly from the panel for easy editing
+
+### Responsive Breakpoints
+
+- **Mobile (< 1024px)**: Bottom sheet with collapse/expand
+- **Desktop (>= 1024px)**: Right side panel with collapse/expand
+
+This breakpoint aligns with the `lg:` Tailwind prefix and provides optimal viewing on tablets and desktops.

--- a/src/lib/icons/ChevronDown.svelte
+++ b/src/lib/icons/ChevronDown.svelte
@@ -1,0 +1,16 @@
+<script>
+	const { styles } = $props();
+</script>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg"
+	viewBox="0 0 24 24"
+	fill="none"
+	stroke="currentColor"
+	stroke-width="2"
+	stroke-linecap="round"
+	stroke-linejoin="round"
+	class="lucide lucide-chevron-down {styles}"
+>
+	<path d="m6 9 6 6 6-6" />
+</svg>

--- a/src/lib/icons/ChevronLeft.svelte
+++ b/src/lib/icons/ChevronLeft.svelte
@@ -1,0 +1,16 @@
+<script>
+	const { styles } = $props();
+</script>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg"
+	viewBox="0 0 24 24"
+	fill="none"
+	stroke="currentColor"
+	stroke-width="2"
+	stroke-linecap="round"
+	stroke-linejoin="round"
+	class="lucide lucide-chevron-left {styles}"
+>
+	<path d="m15 18-6-6 6-6" />
+</svg>

--- a/src/lib/icons/ChevronRight.svelte
+++ b/src/lib/icons/ChevronRight.svelte
@@ -1,0 +1,16 @@
+<script>
+	const { styles } = $props();
+</script>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg"
+	viewBox="0 0 24 24"
+	fill="none"
+	stroke="currentColor"
+	stroke-width="2"
+	stroke-linecap="round"
+	stroke-linejoin="round"
+	class="lucide lucide-chevron-right {styles}"
+>
+	<path d="m9 18 6-6-6-6" />
+</svg>

--- a/src/lib/icons/ChevronUp.svelte
+++ b/src/lib/icons/ChevronUp.svelte
@@ -1,0 +1,16 @@
+<script>
+	const { styles } = $props();
+</script>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg"
+	viewBox="0 0 24 24"
+	fill="none"
+	stroke="currentColor"
+	stroke-width="2"
+	stroke-linecap="round"
+	stroke-linejoin="round"
+	class="lucide lucide-chevron-up {styles}"
+>
+	<path d="m18 15-6-6-6 6" />
+</svg>

--- a/src/lib/icons/XIcon.svelte
+++ b/src/lib/icons/XIcon.svelte
@@ -1,0 +1,17 @@
+<script>
+	const { styles } = $props();
+</script>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg"
+	viewBox="0 0 24 24"
+	fill="none"
+	stroke="currentColor"
+	stroke-width="2"
+	stroke-linecap="round"
+	stroke-linejoin="round"
+	class="lucide lucide-x {styles}"
+>
+	<path d="M18 6 6 18" />
+	<path d="m6 6 12 12" />
+</svg>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -131,7 +131,7 @@
 		{isHomepage
 		? 'h-100 min-h-100 items-start sm:h-[50vh] sm:min-h-[50vh] sm:pt-5'
 		: 'h-fit items-center sm:pt-3'}
-		bg-cover bg-top px-4 py-4 sm:px-6
+		bg-cover bg-top px-4 py-4 sm:px-6 lg:pr-20
 	"
 >
 	{#if isHomepage}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,7 +15,7 @@
 	import ClimbingTypeFilter from './ClimbingTypeFilter.svelte';
 	import GymCardsSection from './GymCardsSection.svelte';
 	import MapSection from './MapSection.svelte';
-	import RoutesDiv from './RoutesDiv.svelte';
+	import RouteComparePanel from './RouteComparePanel.svelte';
 	import SortDropdown from './SortDropdown.svelte';
 
 	let isMobile = $state(false);
@@ -209,11 +209,21 @@
 
 	function handleDestination(event: MouseEvent, gymPlaceId: string) {
 		event.stopPropagation();
+		toggleGymDestination(gymPlaceId);
+	}
 
+	function toggleGymDestination(gymPlaceId: string) {
 		const index = gymPlaceIds.indexOf(gymPlaceId);
 		if (index === -1) {
 			gymPlaceIds.push(gymPlaceId);
 		} else {
+			gymPlaceIds.splice(index, 1);
+		}
+	}
+
+	function removeGymDestination(gymPlaceId: string) {
+		const index = gymPlaceIds.indexOf(gymPlaceId);
+		if (index !== -1) {
 			gymPlaceIds.splice(index, 1);
 		}
 	}
@@ -232,51 +242,53 @@
 	}
 </script>
 
-<section
-	class="mt-4 mb-3 flex w-full flex-col gap-y-2 lg:mb-4 lg:flex-row lg:items-center lg:gap-x-3"
->
-	<RoutesDiv
-		{displayedGyms}
-		{isMobile}
-		{gymPlaceIds}
-		{searchRoutes}
-		{userLocationDisplay}
-	/>
+<div class="pb-20 lg:pb-0 lg:pr-[60px]">
+	<section
+		class="mt-4 mb-3 flex w-full flex-col gap-y-2 lg:mb-4 lg:flex-row lg:items-center lg:gap-x-3"
+	>
+		<div class="flex w-full flex-row gap-2 sm:w-fit">
+			<ClimbingTypeFilter {climbingType} {isMobile} />
 
-	<div class="flex w-full flex-row gap-2 sm:w-fit">
-		<ClimbingTypeFilter {climbingType} {isMobile} />
+			<CityFilter {cities} {isMobile} />
 
-		<CityFilter {cities} {isMobile} />
+			<SortDropdown {selectedSortingOption} onSortChange={handleSortChange} />
 
-		<SortDropdown {selectedSortingOption} onSortChange={handleSortChange} />
+			<Button
+				class="px-2.5 py-1 sm:px-4"
+				onclick={() => {
+					handleViewMode(
+						gymsViewMode === GymsViewMode.CARD
+							? GymsViewMode.MAP
+							: GymsViewMode.CARD
+					);
+				}}
+				aria-label={gymsViewMode}
+			>
+				{#if gymsViewMode === GymsViewMode.CARD}
+					<MapIcon styles="w-4 sm:w-5 stroke-white" />
+				{:else}
+					<ImagesIcon styles="w-4 sm:w-5 stroke-white" />
+				{/if}
+			</Button>
+		</div>
+	</section>
+	{#if gymsViewMode == GymsViewMode.CARD}
+		<GymCardsSection
+			{displayedGyms}
+			{isMobile}
+			{gymPlaceIds}
+			{toggleChildElementVisibility}
+			{handleDestination}
+		/>
+	{:else if gymsViewMode == GymsViewMode.MAP}
+		<MapSection {displayedGyms} />
+	{/if}
+</div>
 
-		<Button
-			class="px-2.5 py-1 sm:px-4"
-			onclick={() => {
-				handleViewMode(
-					gymsViewMode === GymsViewMode.CARD
-						? GymsViewMode.MAP
-						: GymsViewMode.CARD
-				);
-			}}
-			aria-label={gymsViewMode}
-		>
-			{#if gymsViewMode === GymsViewMode.CARD}
-				<MapIcon styles="w-4 sm:w-5 stroke-white" />
-			{:else}
-				<ImagesIcon styles="w-4 sm:w-5 stroke-white" />
-			{/if}
-		</Button>
-	</div>
-</section>
-{#if gymsViewMode == GymsViewMode.CARD}
-	<GymCardsSection
-		{displayedGyms}
-		{isMobile}
-		{gymPlaceIds}
-		{toggleChildElementVisibility}
-		{handleDestination}
-	/>
-{:else if gymsViewMode == GymsViewMode.MAP}
-	<MapSection {displayedGyms} />
-{/if}
+<RouteComparePanel
+	{gymPlaceIds}
+	{displayedGyms}
+	{userLocationDisplay}
+	{searchRoutes}
+	onRemoveGym={removeGymDestination}
+/>

--- a/src/routes/GymCardsSection.svelte
+++ b/src/routes/GymCardsSection.svelte
@@ -50,17 +50,15 @@
 			<div class="gym-title p-2 text-center sm:p-3">
 				<button
 					id="add-destination-{gym.id}"
-					class="absolute top-2 right-2 w-[18px] cursor-pointer sm:visible sm:z-10 sm:w-[24px]"
+					class="absolute top-2 right-2 flex h-8 w-8 cursor-pointer items-center justify-center rounded-full bg-white/80 shadow-sm transition-all hover:bg-white hover:shadow-md sm:visible sm:z-10 sm:h-10 sm:w-10"
 					onclick={(event) => handleDestination(event, gym.placeId)}
 					aria-label="Add or delete a destination"
 				>
 					{#if gymPlaceIds.includes(gym.placeId)}
-						<MapPin
-							styles="w-full stroke-white fill-blue-600 hover:fill-none"
-						/>
+						<MapPin styles="w-5 sm:w-6 stroke-blue-600 fill-blue-200" />
 					{:else}
 						<MapPinPlus
-							styles="w-full stroke-white fill-none hover:stroke-blue-300"
+							styles="w-5 sm:w-6 stroke-slate-600 fill-none hover:stroke-blue-500"
 						/>
 					{/if}
 				</button>

--- a/src/routes/RouteComparePanel.svelte
+++ b/src/routes/RouteComparePanel.svelte
@@ -1,0 +1,341 @@
+<script lang="ts">
+	import { base } from '$app/paths';
+	import { TravelModes } from '$lib/enums/TravelModes';
+	import ChevronDown from '$lib/icons/ChevronDown.svelte';
+	import ChevronLeft from '$lib/icons/ChevronLeft.svelte';
+	import ChevronRight from '$lib/icons/ChevronRight.svelte';
+	import ChevronUp from '$lib/icons/ChevronUp.svelte';
+	import BicyclingIcon from '$lib/icons/commutes/BicyclingIcon.svelte';
+	import DrivingIcon from '$lib/icons/commutes/DrivingIcon.svelte';
+	import TransitIcon from '$lib/icons/commutes/TransitIcon.svelte';
+	import WalkingIcon from '$lib/icons/commutes/WalkingIcon.svelte';
+	import CurrentLocation from '$lib/icons/CurrentLocation.svelte';
+	import MapPin from '$lib/icons/MapPin.svelte';
+	import MapPinPlus from '$lib/icons/MapPinPlus.svelte';
+	import XIcon from '$lib/icons/XIcon.svelte';
+	import type { ClimbingGym } from '$lib/types/types';
+	import { Tooltip } from 'flowbite-svelte';
+
+	interface Props {
+		gymPlaceIds: string[];
+		displayedGyms: ClimbingGym[];
+		userLocationDisplay: string;
+		searchRoutes: (travelMode: TravelModes) => void;
+		onRemoveGym: (placeId: string) => void;
+	}
+
+	const {
+		gymPlaceIds,
+		displayedGyms,
+		userLocationDisplay,
+		searchRoutes,
+		onRemoveGym,
+	}: Props = $props();
+
+	let isExpanded = $state(false);
+	let hasAutoExpandedOnce = $state(false);
+
+	// Auto-expand on first gym add
+	$effect(() => {
+		if (gymPlaceIds.length > 0 && !hasAutoExpandedOnce) {
+			isExpanded = true;
+			hasAutoExpandedOnce = true;
+		}
+	});
+
+	function toggleExpanded() {
+		isExpanded = !isExpanded;
+	}
+
+	const selectedGyms = $derived(
+		displayedGyms.filter((gym) => gymPlaceIds.includes(gym.placeId))
+	);
+
+	const hasGymsSelected = $derived(gymPlaceIds.length > 0);
+
+	const travelModeDisabled = $derived(!hasGymsSelected);
+</script>
+
+<!-- Mobile Bottom Panel (< 1024px) -->
+<div
+	class="fixed right-0 bottom-0 left-0 z-50 border-t border-slate-200 bg-white shadow-lg transition-all duration-300 lg:hidden"
+	style="padding-bottom: env(safe-area-inset-bottom, 0px);"
+>
+	<!-- Collapsed/Header Bar -->
+	<button
+		class="flex w-full cursor-pointer items-center justify-between px-4 py-3"
+		onclick={toggleExpanded}
+		aria-label={isExpanded ? 'Collapse route panel' : 'Expand route panel'}
+	>
+		<div class="flex items-center gap-2">
+			<MapPin styles="w-5 text-blue-600" />
+			{#if hasGymsSelected}
+				<span class="font-medium text-slate-700">
+					Compare routes ({gymPlaceIds.length} selected)
+				</span>
+			{:else}
+				<span class="font-medium text-slate-700">Compare routes</span>
+			{/if}
+		</div>
+		{#if isExpanded}
+			<ChevronDown styles="w-5 text-slate-500" />
+		{:else}
+			<ChevronUp styles="w-5 text-slate-500" />
+		{/if}
+	</button>
+
+	<!-- Expanded Content -->
+	{#if isExpanded}
+		<div class="border-t border-slate-100 px-4 pb-4">
+			<!-- From location -->
+			<div class="flex items-center gap-2 py-3 text-sm">
+				<CurrentLocation styles="w-4 text-slate-500" />
+				<span class="text-slate-600">From: {userLocationDisplay}</span>
+			</div>
+
+			<!-- Selected gyms -->
+			<div class="mb-3">
+				<span class="mb-2 block text-xs text-slate-500">To:</span>
+				{#if selectedGyms.length === 0}
+					<p class="flex items-center gap-1 text-sm text-slate-400">
+						Tap <MapPinPlus styles="w-4 inline" /> on gyms to add
+					</p>
+				{:else}
+					<div class="flex flex-wrap gap-2">
+						{#each selectedGyms as gym (gym.placeId)}
+							<div
+								class="flex items-center gap-1.5 rounded-full bg-slate-100 py-1 pr-1 pl-2"
+							>
+								<img
+									class="h-5 w-5 rounded-full bg-white"
+									src="{base}/{gym.iconUrl}"
+									alt={gym.name}
+								/>
+								<span class="max-w-[100px] truncate text-sm">{gym.name}</span>
+								<button
+									class="rounded-full p-0.5 hover:bg-slate-200"
+									onclick={() => onRemoveGym(gym.placeId)}
+									aria-label="Remove {gym.name}"
+								>
+									<XIcon styles="w-4 text-slate-500" />
+								</button>
+							</div>
+						{/each}
+					</div>
+				{/if}
+			</div>
+
+			<!-- Travel mode buttons -->
+			<div
+				class="grid grid-cols-4 divide-x divide-slate-200 rounded-lg border border-slate-200"
+			>
+				<button
+					onclick={() => searchRoutes(TravelModes.DRIVING)}
+					class="flex cursor-pointer items-center justify-center px-3 py-2.5 transition-colors hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
+					aria-label="Search driving routes"
+					disabled={travelModeDisabled}
+				>
+					<DrivingIcon fillColor={travelModeDisabled ? '#94A3B8' : '#64748B'} />
+				</button>
+
+				<button
+					onclick={() => searchRoutes(TravelModes.PUBLIC_TRANSIT)}
+					class="flex cursor-pointer items-center justify-center px-3 py-2.5 transition-colors hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
+					aria-label="Search public transit routes"
+					disabled={travelModeDisabled}
+				>
+					<TransitIcon fillColor={travelModeDisabled ? '#94A3B8' : '#64748B'} />
+				</button>
+
+				<button
+					onclick={() => searchRoutes(TravelModes.BICYCLING)}
+					class="flex cursor-pointer items-center justify-center px-3 py-2.5 transition-colors hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
+					aria-label="Search bicycling routes"
+					disabled={travelModeDisabled}
+				>
+					<BicyclingIcon
+						fillColor={travelModeDisabled ? '#94A3B8' : '#64748B'}
+					/>
+				</button>
+
+				<button
+					onclick={() => searchRoutes(TravelModes.WALKING)}
+					class="flex cursor-pointer items-center justify-center px-3 py-2.5 transition-colors hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
+					aria-label="Search walking routes"
+					disabled={travelModeDisabled}
+				>
+					<WalkingIcon fillColor={travelModeDisabled ? '#94A3B8' : '#64748B'} />
+				</button>
+			</div>
+		</div>
+	{/if}
+</div>
+
+<!-- Desktop Right Side Panel (>= 1024px) -->
+<div
+	class="fixed top-0 right-0 bottom-0 z-40 hidden border-l border-slate-200 bg-white shadow-lg transition-all duration-300 lg:block"
+	class:w-[280px]={isExpanded}
+	class:w-[60px]={!isExpanded}
+>
+	<!-- Collapsed state -->
+	{#if !isExpanded}
+		<button
+			class="flex h-full w-full cursor-pointer flex-col items-center pt-4"
+			onclick={toggleExpanded}
+			aria-label="Expand route panel"
+		>
+			<MapPin styles="w-6 text-blue-600" />
+			{#if hasGymsSelected}
+				<div class="mt-3 flex flex-col items-center gap-1.5">
+					{#each selectedGyms as gym (gym.placeId)}
+						<img
+							class="h-7 w-7 rounded-full bg-white"
+							src="{base}/{gym.iconUrl}"
+							alt={gym.name}
+						/>
+					{/each}
+				</div>
+			{/if}
+			<div class="mt-4">
+				<ChevronLeft styles="w-5 text-slate-400" />
+			</div>
+		</button>
+	{:else}
+		<!-- Expanded state -->
+		<div class="flex h-full flex-col">
+			<!-- Header -->
+			<div
+				class="flex items-center justify-between border-b border-slate-100 px-4 py-3"
+			>
+				<div class="flex items-center gap-2">
+					<MapPin styles="w-5 text-blue-600" />
+					<span class="font-medium text-slate-700">Compare routes</span>
+				</div>
+				<button
+					class="cursor-pointer rounded p-1 hover:bg-slate-100"
+					onclick={toggleExpanded}
+					aria-label="Collapse route panel"
+				>
+					<ChevronRight styles="w-5 text-slate-500" />
+				</button>
+			</div>
+
+			<!-- Travel mode buttons (fixed at top) -->
+			<div class="px-4 pt-4">
+				<div
+					class="grid grid-cols-4 divide-x divide-slate-200 rounded-lg border border-slate-200"
+				>
+					<button
+						id="travel-driving"
+						onclick={() => searchRoutes(TravelModes.DRIVING)}
+						class="flex cursor-pointer items-center justify-center px-3 py-2.5 transition-colors hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
+						aria-label="Search driving routes"
+						disabled={travelModeDisabled}
+					>
+						<DrivingIcon
+							fillColor={travelModeDisabled ? '#94A3B8' : '#64748B'}
+						/>
+					</button>
+					<Tooltip triggeredBy="#travel-driving" type="light" class="z-50">
+						Driving
+					</Tooltip>
+
+					<button
+						id="travel-transit"
+						onclick={() => searchRoutes(TravelModes.PUBLIC_TRANSIT)}
+						class="flex cursor-pointer items-center justify-center px-3 py-2.5 transition-colors hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
+						aria-label="Search public transit routes"
+						disabled={travelModeDisabled}
+					>
+						<TransitIcon
+							fillColor={travelModeDisabled ? '#94A3B8' : '#64748B'}
+						/>
+					</button>
+					<Tooltip triggeredBy="#travel-transit" type="light" class="z-50">
+						Transit
+					</Tooltip>
+
+					<button
+						id="travel-bicycling"
+						onclick={() => searchRoutes(TravelModes.BICYCLING)}
+						class="flex cursor-pointer items-center justify-center px-3 py-2.5 transition-colors hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
+						aria-label="Search bicycling routes"
+						disabled={travelModeDisabled}
+					>
+						<BicyclingIcon
+							fillColor={travelModeDisabled ? '#94A3B8' : '#64748B'}
+						/>
+					</button>
+					<Tooltip triggeredBy="#travel-bicycling" type="light" class="z-50">
+						Bicycling
+					</Tooltip>
+
+					<button
+						id="travel-walking"
+						onclick={() => searchRoutes(TravelModes.WALKING)}
+						class="flex cursor-pointer items-center justify-center px-3 py-2.5 transition-colors hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
+						aria-label="Search walking routes"
+						disabled={travelModeDisabled}
+					>
+						<WalkingIcon
+							fillColor={travelModeDisabled ? '#94A3B8' : '#64748B'}
+						/>
+					</button>
+					<Tooltip triggeredBy="#travel-walking" type="light" class="z-50">
+						Walking
+					</Tooltip>
+				</div>
+			</div>
+
+			<!-- Scrollable Content -->
+			<div class="flex-1 overflow-y-auto p-4">
+				<!-- From location -->
+				<div class="mb-4">
+					<span class="mb-1 block text-xs font-medium text-slate-500"
+						>From:</span
+					>
+					<div class="flex items-center gap-2">
+						<CurrentLocation styles="w-4 text-slate-500" />
+						<span class="text-sm text-slate-700">{userLocationDisplay}</span>
+					</div>
+				</div>
+
+				<!-- To destinations -->
+				<div>
+					<span class="mb-2 block text-xs font-medium text-slate-500">To:</span>
+					{#if selectedGyms.length === 0}
+						<p class="flex items-center gap-1 text-sm text-slate-400">
+							Click <MapPinPlus styles="w-4 inline" /> on gyms to add
+						</p>
+					{:else}
+						<div class="space-y-2">
+							{#each selectedGyms as gym (gym.placeId)}
+								<div
+									class="flex items-center justify-between rounded-lg bg-slate-50 p-2"
+								>
+									<div class="flex items-center gap-2">
+										<img
+											class="h-6 w-6 rounded-full bg-white"
+											src="{base}/{gym.iconUrl}"
+											alt={gym.name}
+										/>
+										<span class="max-w-[160px] truncate text-sm"
+											>{gym.name}</span
+										>
+									</div>
+									<button
+										class="cursor-pointer rounded p-1 hover:bg-slate-200"
+										onclick={() => onRemoveGym(gym.placeId)}
+										aria-label="Remove {gym.name}"
+									>
+										<XIcon styles="w-4 text-slate-500" />
+									</button>
+								</div>
+							{/each}
+						</div>
+					{/if}
+				</div>
+			</div>
+		</div>
+	{/if}
+</div>


### PR DESCRIPTION
## Summary

This PR improves the discoverability of the route comparison feature by replacing the top RoutesDiv with a responsive sticky panel.

### Problem

Two key discoverability issues with the route comparison feature:
1. **RoutesDiv visibility**: The route comparison buttons at the top of the page were not being noticed by users
2. **Add destination discoverability**: The MapPinPlus button on gym cards wasn't intuitive enough

### UX Options Considered

| Option | Description | Verdict |
|--------|-------------|---------|
| A. Current layout + improvements | Make buttons bigger | Doesn't solve core discoverability |
| B. Separate compare page | Dedicated `/compare` page | Too much navigation friction |
| C. Mode toggle | Explore/Compare toggle | Overcomplicates the interaction |
| **D. Sticky panel** | Bottom sheet (mobile) / Side panel (desktop) | **Selected** - familiar pattern, always accessible |

See [`docs/ux-route-comparison-options.md`](docs/ux-route-comparison-options.md) for full analysis.

### Solution: Responsive Route Compare Panel

- **Mobile (< 1024px)**: Sticky bottom sheet with collapse/expand
- **Desktop (≥ 1024px)**: Sticky right side panel with collapse/expand

### Key UX Improvements

- Panel is **always visible** (even when empty) to teach users the feature exists
- **Auto-expands on first gym selection** for immediate feedback
- Travel mode buttons **disabled when no gyms selected**
- **Gym icons shown in collapsed state** for quick reference
- **Remove gyms directly** from the panel

## Test plan

- [ ] Verify bottom panel is visible and sticky on mobile (< 1024px)
- [ ] Verify side panel is visible and sticky on desktop (≥ 1024px)
- [ ] Test adding gyms via MapPinPlus button - panel should auto-expand on first add
- [ ] Test removing gyms from expanded panel
- [ ] Verify travel mode buttons are disabled when no gyms selected
- [ ] Test collapse/expand functionality on both layouts
- [ ] Verify safe area padding works on iPhone (no overlap with home bar)

🤖 Generated with [Claude Code](https://claude.ai/code)